### PR TITLE
feat(tui): fix single-chunk bracketed paste being silently dropped

### DIFF
--- a/src/tui/components/ChatInput.tsx
+++ b/src/tui/components/ChatInput.tsx
@@ -234,13 +234,22 @@ export function ChatInput({
     }
 
     if (input.includes('\u001b')) {
-      if (handleEscapeSequence(input)) {
-        return;
+      // Check for bracketed paste markers - these must reach normalizePastedText
+      // even though they start with ESC. Single-chunk pastes from some terminals
+      // arrive as: \u001b[200~content\u001b[201~
+      const hasBracketedPaste =
+        input.includes('\u001b[200~') || input.includes('\u001b[201~');
+
+      if (!hasBracketedPaste) {
+        if (handleEscapeSequence(input)) {
+          return;
+        }
+        // Ignore unknown escape sequences to avoid garbage insertion
+        if (input.startsWith('\u001b')) {
+          return;
+        }
       }
-      // Ignore unknown escape sequences to avoid garbage insertion
-      if (input.startsWith('\u001b')) {
-        return;
-      }
+      // Bracketed paste falls through to normalizePastedText below
     }
 
     const textToInsert = input.length > 1 ? normalizePastedText(input) : input;


### PR DESCRIPTION
## Summary

Prevent single-chunk bracketed paste sequences from being silently dropped in the TUI `ChatInput` component by adjusting ESC handling so that bracketed paste content is correctly passed through to `normalizePastedText`, without changing any user-facing configuration or behavior outside of this bug fix.

## Problem

When a single-chunk bracketed paste sequence arrives (e.g., `\u001b[200~hello world\u001b[201~`), the code:
1. Detects ESC character via `input.includes('\u001b')`
2. Fails to match in `handleEscapeSequence()` (returns `false`)
3. Early-returns because `input.startsWith('\u001b')` is true

This causes the paste to be silently dropped, never reaching `normalizePastedText()` which already correctly strips bracketed paste markers.

## Changes

- **Phase 1:** Setup verification (branch exists)
- **Phase 2:** Core implementation - Added bracketed paste detection guard in `ChatInput.tsx`
  - Added `hasBracketedPaste` check before the unknown-ESC discard
  - Only apply unknown-ESC discard when `!hasBracketedPaste`
  - Added inline comment explaining the guard
- **Phase 3-5:** Test verification, integration testing, code quality checks

## Testing

- [x] Unit tests: 158 passing (including 69 input-utils tests)
- [x] Build succeeds
- [x] TypeScript type checking passes
- [x] Scope limited to `ChatInput.tsx` only

## Files Changed

- `src/tui/components/ChatInput.tsx` - Added 9-line bracketed paste detection guard

## Acceptance Criteria Met

- ✅ Single-chunk bracketed paste works (via guard + existing normalizePastedText)
- ✅ Multi-chunk paste unchanged (existing tests verify)
- ✅ Unknown ESC still ignored (guard preserves this behavior)
- ✅ Navigation shortcuts unchanged (guard only affects inputs with paste markers)
- ✅ Scope confined to ChatInput (verified via git status)
- ✅ Tests passing (158 tests passed)

---

🤖 Generated with Claude Code