### PR TITLE
feat(tui): polish summary Goal line with imperative sentence and no truncation

### DIFF
--- a/src/tui/components/SpecCompletionSummary.test.tsx
+++ b/src/tui/components/SpecCompletionSummary.test.tsx
@@ -42,6 +42,26 @@ describe('normalizeRecap', () => {
     expect(normalizeRecap('got it— using React for the frontend')).toBe('Using React for the frontend');
   });
 
+  it('strips "you\'re aiming to" prefix', () => {
+    expect(normalizeRecap("you're aiming to unblock loops with an action inbox")).toBe('Unblock loops with an action inbox');
+  });
+
+  it('strips "you\'re looking to" prefix', () => {
+    expect(normalizeRecap("you're looking to add dark mode support")).toBe('Add dark mode support');
+  });
+
+  it('strips "I understand" prefix', () => {
+    expect(normalizeRecap('I understand that you need a login page')).toBe('You need a login page');
+  });
+
+  it('strips "so you" prefix', () => {
+    expect(normalizeRecap('so you want to build a REST API')).toBe('Want to build a REST API');
+  });
+
+  it('strips "to summarize" prefix', () => {
+    expect(normalizeRecap('to summarize, the feature needs auth and roles')).toBe('The feature needs auth and roles');
+  });
+
   it('capitalizes the first character', () => {
     expect(normalizeRecap('  hello')).toBe('Hello');
   });
@@ -159,6 +179,30 @@ describe('extractRecap', () => {
       msg('assistant', 'Got it - Express with PostgreSQL for the backend API.'),
     ];
     const result = extractRecap(messages, 'task-app');
+    expect(result.decisions.length).toBeGreaterThan(0);
+  });
+
+  it('extracts goal from "you\'re aiming to" recap pattern', () => {
+    const messages = [
+      msg('user', 'I need to unblock loops waiting for user input'),
+      msg('assistant', "You're aiming to unblock loops by adding a file-based action inbox so the TUI can capture user decisions without extra terminals."),
+    ];
+    const result = extractRecap(messages, 'unblock-loops');
+    // Should detect the AI recap and produce a clean goal, not "Implement you're aiming to..."
+    expect(result.goalCandidate).not.toContain("you're");
+    expect(result.goalCandidate).toContain('unblock');
+  });
+
+  it('extracts decisions from varied AI recap phrasings', () => {
+    const messages = [
+      msg('user', 'Build a notification system'),
+      msg('assistant', "You're looking to build a real-time notification system with push support."),
+      msg('user', 'Use WebSockets for real-time'),
+      msg('assistant', "I understand that you want WebSocket-based delivery with fallback to polling."),
+      msg('user', 'Store in PostgreSQL'),
+      msg('assistant', "So you need PostgreSQL storage with a read/unread status per user."),
+    ];
+    const result = extractRecap(messages, 'notifications');
     expect(result.decisions.length).toBeGreaterThan(0);
   });
 

--- a/src/tui/components/SpecCompletionSummary.tsx
+++ b/src/tui/components/SpecCompletionSummary.tsx
@@ -30,13 +30,23 @@ export interface SpecCompletionSummaryProps {
 
 const MAX_RECAP_SOURCE_LENGTH = 1200;
 
-/** Strip filler prefixes ('you want', 'understood', 'got it') from AI recap text and capitalize. */
+/** Strip filler prefixes from AI recap text and capitalize. */
 export function normalizeRecap(text: string): string {
   let result = text.trim();
   result = result.replace(/^[^a-z0-9]+/i, '');
   result = result.replace(/^you want\s*/i, '');
+  result = result.replace(/^you're\s+\w+ing\s+to\s*/i, '');
+  result = result.replace(/^you'd like to\s*/i, '');
+  result = result.replace(/^you need to\s*/i, '');
+  result = result.replace(/^you would like to\s*/i, '');
   result = result.replace(/^understood[:,]?\s*/i, '');
   result = result.replace(/^got it[-\u2014:]*\s*/i, '');
+  result = result.replace(/^i understand\s*(that\s*)?/i, '');
+  result = result.replace(/^so you\s*/i, '');
+  result = result.replace(/^to summarize[:,]?\s*/i, '');
+  result = result.replace(/^in summary[:,]?\s*/i, '');
+  result = result.replace(/^here'?s what I understand[:,]?\s*/i, '');
+  if (!result) return text.trim();
   return result.charAt(0).toUpperCase() + result.slice(1);
 }
 
@@ -96,7 +106,9 @@ export function extractRecap(messages: Message[], featureName: string) {
 
   const recapCandidates = assistantParagraphs
     .map((para) => para.replace(/^[^a-z0-9]+/i, '').trim())
-    .filter((para) => /^(you want|understood|got it)/i.test(para))
+    .filter((para) =>
+      /^(you want|you're\s+\w+ing\s+to|you'd like|you need|you would like|understood|got it|i understand|so you|to summarize|in summary|here'?s what)/i.test(para)
+    )
     .map((para) => para.split(/next question:/i)[0]!.trim())
     .filter((para) => para.length > 0);
 

--- a/src/tui/utils/polishGoal.test.ts
+++ b/src/tui/utils/polishGoal.test.ts
@@ -124,6 +124,26 @@ describe('polishGoalSentence', () => {
     expect(result).toBe('Refactor the auth module.');
   });
 
+  it('rewrites "You\'re aiming to …" to imperative form', () => {
+    const result = polishGoalSentence("You're aiming to unblock loops by adding an action inbox.");
+    expect(result).toBe('Implement unblock loops by adding an action inbox.');
+  });
+
+  it('rewrites "You\'d like to …" to imperative form', () => {
+    const result = polishGoalSentence("You'd like to add dark mode support.");
+    expect(result).toBe('Add dark mode support.');
+  });
+
+  it('rewrites "You want to …" to imperative form', () => {
+    const result = polishGoalSentence('You want to build a notification system.');
+    expect(result).toBe('Build a notification system.');
+  });
+
+  it('rewrites "You need to …" to imperative form', () => {
+    const result = polishGoalSentence('You need to fix the auth flow.');
+    expect(result).toBe('Fix the auth flow.');
+  });
+
   it('passes through common action verbs after stripping framing (no double-verb)', () => {
     const result = polishGoalSentence('I want to achieve a faster build pipeline.');
     // Strips "I want to", leaving "achieve …" — now in allowed verbs list

--- a/src/tui/utils/polishGoal.ts
+++ b/src/tui/utils/polishGoal.ts
@@ -55,10 +55,14 @@ const FRAMING_PATTERNS: Array<[RegExp, string]> = [
   [/^i would like to\s*/i, ''],
   [/^we will\s*/i, ''],
   [/^we want to\s*/i, ''],
+  [/^we need to\s*/i, ''],
+  [/^you're\s+\w+ing\s+to\s*/i, ''],
+  [/^you'd like to\s*/i, ''],
+  [/^you want to\s*/i, ''],
+  [/^you need to\s*/i, ''],
   [/^this spec covers\s*/i, ''],
   [/^this spec describes\s*/i, ''],
   [/^the goal is to\s*/i, ''],
-  [/^we need to\s*/i, ''],
   // Handles normalizeRecap output like "To build …" (stripped "you want" prefix)
   [/^to\s+/i, ''],
 ];


### PR DESCRIPTION
## Summary

- Polish the `/new` completion Summary "Goal" line so it is an agent-authored, imperative, single-sentence recap (not verbatim user input), sourced via a defined fallback chain (AI recap → Key decisions → user request), and displayed without naive truncation (wrap to terminal width)
- Introduce `src/tui/utils/polishGoal.ts` with pure, deterministic string-processing functions (`selectGoalSource`, `polishGoalSentence`) for goal selection and formatting
- Remove 160-char `summarizeText()` truncation on the Goal line, letting Ink wrap naturally

## Changes

### Phase 1: Extract & Refactor Utilities (`src/tui/utils/polishGoal.ts`)
- `selectGoalSource({ aiRecap, keyDecisions, userRequest })` — 3-tier fallback chain with whitespace-skip and bullet-stripping for decisions
- `polishGoalSentence(text)` — whitespace normalization, framing phrase removal ("I want to…" → imperative), imperative verb enforcement from controlled verb list, single-sentence enforcement, punctuation normalization

### Phase 2: Integrate into Component (`SpecCompletionSummary.tsx`)
- Refactored `extractRecap()` to output structured data feeding `selectGoalSource()`
- Piped selected source through `polishGoalSentence()` for final goal text
- Removed `summarizeText()` wrapping on Goal line

### Phase 3: Tests
- 233-line unit test suite for `polishGoal.ts` covering source selection, imperative rewriting, sentence enforcement, edge cases
- Updated `SpecCompletionSummary.test.tsx` with render tests for full-text rendering (no truncation) and imperative format

### Follow-up fix
- Expanded imperative verb list (Build, Design, Integrate, Migrate, Optimize, Remove, Replace, Set, Configure, Ensure, Establish, Define, Develop, Deploy, Extend, Extract, Generate, Handle, Introduce, Maintain, Manage, Monitor, Organize, Polish, Prevent, Provide, Publish, Reduce, Resolve, Restore, Restructure, Rewrite, Scaffold, Secure, Simplify, Standardize, Streamline, Test, Transform, Upgrade, Validate, Verify, Wire, Wrap, Apply, Automate) to prevent double-verb output like "Implement build…"

## Test plan
- [x] 563 tests passing (36 test files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Unit tests for `selectGoalSource` — fallback chain, whitespace skip, bullet stripping
- [x] Unit tests for `polishGoalSentence` — imperative rewriting, single sentence, edge cases
- [x] Component render tests — full text present (not truncated), imperative format verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)