### PR TITLE
feat: add headless `wiggum sync` CLI command

### DIFF
--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted mocks
+const {
+  mockScan,
+  mockEnhance,
+  mockSaveContext,
+  mockToPersistedScanResult,
+  mockToPersistedAIAnalysis,
+  mockGetGitMetadata,
+  mockGetAvailableProvider,
+} = vi.hoisted(() => ({
+  mockScan: vi.fn(),
+  mockEnhance: vi.fn(),
+  mockSaveContext: vi.fn(),
+  mockToPersistedScanResult: vi.fn().mockReturnValue({ mocked: 'scanResult' }),
+  mockToPersistedAIAnalysis: vi.fn().mockReturnValue({ mocked: 'aiAnalysis' }),
+  mockGetGitMetadata: vi.fn().mockResolvedValue({
+    gitCommitHash: 'abc123',
+    gitBranch: 'main',
+  }),
+  mockGetAvailableProvider: vi.fn().mockReturnValue('anthropic'),
+}));
+
+vi.mock('../scanner/index.js', () => {
+  class MockScanner {
+    scan = mockScan;
+  }
+  return { Scanner: MockScanner };
+});
+
+vi.mock('../ai/enhancer.js', () => {
+  class MockAIEnhancer {
+    enhance = mockEnhance;
+    constructor() {}
+  }
+  return { AIEnhancer: MockAIEnhancer };
+});
+
+vi.mock('../context/index.js', () => ({
+  saveContext: mockSaveContext,
+  toPersistedScanResult: mockToPersistedScanResult,
+  toPersistedAIAnalysis: mockToPersistedAIAnalysis,
+  getGitMetadata: mockGetGitMetadata,
+}));
+
+vi.mock('../ai/providers.js', () => ({
+  getAvailableProvider: mockGetAvailableProvider,
+  AVAILABLE_MODELS: {
+    anthropic: [{ value: 'claude-sonnet-4-6', label: 'Sonnet 4.6', hint: 'recommended' }],
+    openai: [
+      { value: 'gpt-5.2', label: 'GPT-5.2', hint: 'most capable' },
+      { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', hint: 'best for code' },
+    ],
+  },
+  normalizeModelId: vi.fn((_provider: string, modelId: string) => modelId),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { syncCommand } from './sync.js';
+
+describe('syncCommand', () => {
+  let mockExit: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAvailableProvider.mockReturnValue('anthropic');
+    mockScan.mockResolvedValue({ files: [], detections: [] });
+    mockEnhance.mockResolvedValue({
+      files: [],
+      detections: [],
+      aiAnalysis: { summary: 'test' },
+    });
+    mockSaveContext.mockResolvedValue(undefined);
+
+    mockExit = vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExit.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('happy path: scans, enhances, saves context, prints path', async () => {
+    await expect(syncCommand()).rejects.toThrow('process.exit(0)');
+
+    expect(mockScan).toHaveBeenCalledOnce();
+    expect(mockEnhance).toHaveBeenCalledOnce();
+    expect(mockGetGitMetadata).toHaveBeenCalledOnce();
+    expect(mockSaveContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gitCommitHash: 'abc123',
+        gitBranch: 'main',
+      }),
+      expect.any(String),
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('.context.json'),
+    );
+  });
+
+  it('exits with error when no provider available', async () => {
+    mockGetAvailableProvider.mockReturnValue(null);
+
+    await expect(syncCommand()).rejects.toThrow('process.exit(1)');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No AI provider available'),
+    );
+    expect(mockScan).not.toHaveBeenCalled();
+  });
+
+  it('exits with error when AI enhancement fails', async () => {
+    mockEnhance.mockResolvedValue({
+      files: [],
+      detections: [],
+      aiError: 'Model rate limited',
+    });
+
+    await expect(syncCommand()).rejects.toThrow('process.exit(1)');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('AI analysis failed'),
+    );
+    expect(mockSaveContext).not.toHaveBeenCalled();
+  });
+
+  it('propagates scanner errors', async () => {
+    mockScan.mockRejectedValue(new Error('Permission denied'));
+
+    await expect(syncCommand()).rejects.toThrow('Permission denied');
+
+    expect(mockEnhance).not.toHaveBeenCalled();
+    expect(mockSaveContext).not.toHaveBeenCalled();
+  });
+
+  it('uses OpenAI model when only OpenAI provider is available', async () => {
+    mockGetAvailableProvider.mockReturnValue('openai');
+
+    await expect(syncCommand()).rejects.toThrow('process.exit(0)');
+
+    // Should complete successfully with OpenAI provider
+    expect(mockScan).toHaveBeenCalledOnce();
+    expect(mockEnhance).toHaveBeenCalledOnce();
+    expect(mockSaveContext).toHaveBeenCalledOnce();
+  });
+});

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,79 @@
+/**
+ * Headless Sync Command
+ * Runs project scan + AI enhancement and persists context to .ralph/.context.json
+ * CLI equivalent of the TUI /sync command, for non-interactive use.
+ */
+
+import { join } from 'node:path';
+import { logger } from '../utils/logger.js';
+import { Scanner } from '../scanner/index.js';
+import { AIEnhancer } from '../ai/enhancer.js';
+import {
+  saveContext,
+  toPersistedScanResult,
+  toPersistedAIAnalysis,
+  getGitMetadata,
+} from '../context/index.js';
+import {
+  getAvailableProvider,
+  AVAILABLE_MODELS,
+  normalizeModelId,
+} from '../ai/providers.js';
+
+export async function syncCommand(): Promise<void> {
+  const projectRoot = process.cwd();
+
+  // Detect provider
+  const provider = getAvailableProvider();
+  if (!provider) {
+    console.error(
+      'Error: No AI provider available. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY.',
+    );
+    process.exit(1);
+  }
+
+  // Resolve model
+  const recommendedModel = AVAILABLE_MODELS[provider].find(
+    (m) => m.hint?.includes('recommended'),
+  );
+  const defaultModel = recommendedModel?.value ?? AVAILABLE_MODELS[provider][0].value;
+  const model = normalizeModelId(provider, defaultModel);
+
+  logger.info('Scanning project...');
+
+  // Step 1: Scan
+  const scanner = new Scanner();
+  const scanResult = await scanner.scan(projectRoot);
+
+  logger.info('Running AI analysis...');
+
+  // Step 2: AI enhancement
+  const enhancer = new AIEnhancer({
+    provider,
+    model,
+    agentic: true,
+  });
+  const enhanced = await enhancer.enhance(scanResult);
+
+  if (enhanced.aiError) {
+    console.error(`Error: AI analysis failed: ${enhanced.aiError}`);
+    process.exit(1);
+  }
+
+  // Step 3: Persist
+  const git = await getGitMetadata(projectRoot);
+  await saveContext(
+    {
+      lastAnalyzedAt: new Date().toISOString(),
+      gitCommitHash: git.gitCommitHash,
+      gitBranch: git.gitBranch,
+      scanResult: toPersistedScanResult(enhanced),
+      aiAnalysis: toPersistedAIAnalysis(enhanced.aiAnalysis),
+    },
+    projectRoot,
+  );
+
+  const contextPath = join(projectRoot, '.ralph', '.context.json');
+  console.log(contextPath);
+  process.exit(0);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockRenderApp, mockRunCommand, mockMonitorCommand, mockHandleConfigCommand, mockIsCI, mockNewAutoCommand } = vi.hoisted(() => {
+const { mockRenderApp, mockRunCommand, mockMonitorCommand, mockHandleConfigCommand, mockIsCI, mockNewAutoCommand, mockSyncCommand } = vi.hoisted(() => {
   const mockRenderApp = vi.fn().mockReturnValue({
     unmount: vi.fn(),
     waitUntilExit: vi.fn().mockResolvedValue(undefined),
@@ -12,7 +12,8 @@ const { mockRenderApp, mockRunCommand, mockMonitorCommand, mockHandleConfigComma
   );
   const mockIsCI = vi.fn().mockReturnValue(false);
   const mockNewAutoCommand = vi.fn().mockResolvedValue(undefined);
-  return { mockRenderApp, mockRunCommand, mockMonitorCommand, mockHandleConfigCommand, mockIsCI, mockNewAutoCommand };
+  const mockSyncCommand = vi.fn().mockResolvedValue(undefined);
+  return { mockRenderApp, mockRunCommand, mockMonitorCommand, mockHandleConfigCommand, mockIsCI, mockNewAutoCommand, mockSyncCommand };
 });
 
 // Mock all heavy dependencies before imports
@@ -82,6 +83,10 @@ vi.mock('./commands/config.js', () => ({
 
 vi.mock('./commands/new-auto.js', () => ({
   newAutoCommand: mockNewAutoCommand,
+}));
+
+vi.mock('./commands/sync.js', () => ({
+  syncCommand: mockSyncCommand,
 }));
 
 import { main, parseCliArgs } from './index.js';
@@ -753,5 +758,21 @@ describe('main', () => {
     const helpText = consoleLogSpy.mock.calls[0][0] as string;
     expect(helpText).toContain('--auto');
     expect(helpText).toContain('--goals');
+  });
+
+  it('sync → calls syncCommand', async () => {
+    process.argv = ['node', 'ralph.js', 'sync'];
+    await main();
+
+    expect(mockSyncCommand).toHaveBeenCalledOnce();
+    expect(mockRenderApp).not.toHaveBeenCalled();
+  });
+
+  it('--help lists sync command', async () => {
+    process.argv = ['node', 'ralph.js', '--help'];
+    await main();
+
+    const helpText = consoleLogSpy.mock.calls[0][0] as string;
+    expect(helpText).toContain('wiggum sync');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,6 +266,7 @@ Usage:
   wiggum new <name>         Create new feature spec (TUI)
   wiggum run <feature>      Run feature development loop
   wiggum monitor <feature>  Monitor a running feature loop
+  wiggum sync               Refresh project context (scan + AI analysis)
   wiggum config [args...]   Manage API keys and settings
 
 Options for run:
@@ -411,6 +412,12 @@ Press Esc to cancel any operation.
       } else {
         await monitorCommand(feature, { interval });
       }
+      break;
+    }
+
+    case 'sync': {
+      const { syncCommand } = await import('./commands/sync.js');
+      await syncCommand();
       break;
     }
 


### PR DESCRIPTION
## Summary

- Extracts the TUI-only `/sync` logic into a standalone `wiggum sync` CLI command for non-interactive use (OpenClaw orchestrator on VPS)
- Detects provider from environment, scans the project, runs AI enhancement, and persists context to `.ralph/.context.json`
- Prints the context file path to stdout for scripting

## Changes

| File | Change |
|------|--------|
| `src/commands/sync.ts` | New headless sync command |
| `src/commands/sync.test.ts` | 5 unit tests |
| `src/index.ts` | Add `case 'sync':` route + help text |
| `src/index.test.ts` | 2 routing tests |

## Usage

```bash
# Refresh project context headlessly
wiggum sync

# Pipe context path
CONTEXT=$(wiggum sync 2>/dev/null)
```

## Test plan

- [x] 7 new tests (5 sync + 2 index routing)
- [x] All 862 tests pass
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)